### PR TITLE
RDKVREFPLT-4215:  do_rootfs error nothing provides volatile-binds

### DIFF
--- a/recipes-core/images/application-test-image.bb
+++ b/recipes-core/images/application-test-image.bb
@@ -6,6 +6,8 @@ IMAGE_INSTALL = " \
                  packagegroup-middleware-layer \
                  packagegroup-application-layer \
                  "
+IMAGE_INSTALL:append = "volatile-binds"
+
 inherit core-image
 
 inherit custom-rootfs-creation


### PR DESCRIPTION
Reason for the change: The volatile-bind is an all-architecture package that is expected to built across layers and included in all image targets via IMAGE_INSTALL. It generates systemd units for the VOLATILE_BINDS configured in each layer.