### PR TITLE
RDKVREFPLT-4791: Fix for DAB compliance suite timeout issue.

### DIFF
--- a/recipes-thirdparty/mosquitto/mosquitto_%.bbappend
+++ b/recipes-thirdparty/mosquitto/mosquitto_%.bbappend
@@ -1,0 +1,7 @@
+do_install:append () {
+   if [ -f "${D}${sysconfdir}/mosquitto/mosquitto.conf" ]; then
+       rm -f ${D}${sysconfdir}/mosquitto/mosquitto.conf
+   fi
+}
+
+FILES:${PN}-dev:remove = "${sysconfdir}/mosquitto/mosquitto.conf"


### PR DESCRIPTION
Reason for change:
	*mosquitto package is providing a generic conf file.
	*Removing generic conf file.
Test Procedure: build and run dab test cases.
Risks: High.