### PR TITLE
[RDKVREFPLT-4862] WPEFramework port 9998 is not open for external network communication in RDK-E Application build

### DIFF
--- a/recipes-core/images/application-test-image.bb
+++ b/recipes-core/images/application-test-image.bb
@@ -31,7 +31,7 @@ update_dropbearkey_path() {
    fi
 }
 
-ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "debug-variant", "wpeframework_binding_patch; ", "", d)}'
+ROOTFS_POSTPROCESS_COMMAND += "wpeframework_binding_patch; "
 
 wpeframework_binding_patch(){
     sed -i "s/127.0.0.1/0.0.0.0/g" ${IMAGE_ROOTFS}/etc/WPEFramework/config.json


### PR DESCRIPTION
Added the wpeframework_binding_patch into rootfs_postprocess_command to connect the Thunder UI via external network communication and also removed the distro check as it is needed by default