### PR TITLE
RDKVREFPLT-4883: lib32-nss package error during image build.

### DIFF
--- a/recipes-core/images/application-test-image.bb
+++ b/recipes-core/images/application-test-image.bb
@@ -1,6 +1,9 @@
 SUMMARY = "RDKE Bootable Image with App support"
 
 LICENSE = "MIT"
+
+DEPENDS += "nss-native"
+
 IMAGE_INSTALL = " \
                  packagegroup-vendor-layer \
                  packagegroup-middleware-layer \


### PR DESCRIPTION
lib32-nss package error during application image build
Reason for change:
	*lib32-nss package is missing in the build
	*updated package group with nss package.
	*ref : https://github.com/rdkcentral/meta-image-assembler/pull/4
Test Procedure: build image.
Risks: High.

Signed-off-by: fasil kv <fasil_KV@comcast.com>