### PR TITLE
PREMIUMAPP-3146: Update dab-adapter revision

### DIFF
--- a/conf/machine/include/package_revisions.inc
+++ b/conf/machine/include/package_revisions.inc
@@ -11,7 +11,7 @@ PACKAGE_ARCH:pn-residentui = "${APP_LAYER_ARCH}"
 
 PV:pn-dab-adapter = "0.7.0"
 PR:pn-dab-adapter = "r0"
-SRCREV:pn-dab-adapter = "ccfa32fc41126ed320b903b7a7cf468e98984f8a"
+SRCREV:pn-dab-adapter = "4755f391c7e7b112c9cf285ce99013ddc8ee9b82"
 PACKAGE_ARCH:pn-dab-adapter = "${APP_LAYER_ARCH}"
 
 PV:pn-mosquitto = "2.0.14"

--- a/recipes-thirdparty/dab-adapter/dab-adapter_0.7.0.bb
+++ b/recipes-thirdparty/dab-adapter/dab-adapter_0.7.0.bb
@@ -8,7 +8,7 @@ inherit cargo
 # how to get dab-adapter could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/dab-adapter/0.6.0"
 SRC_URI += "git://github.com/device-automation-bus/dab-adapter-rs.git;protocol=https;nobranch=1;branch=v0.7.0"
-SRCREV = "ccfa32fc41126ed320b903b7a7cf468e98984f8a"
+SRCREV = "4755f391c7e7b112c9cf285ce99013ddc8ee9b82"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 PV:append = ".AUTOINC+1c497e1c04"


### PR DESCRIPTION
The new version includes fixes for: PREMIUMAPP-3146, PREMIUMAPP-3147, PREMIUMAPP-3148 and PREMIUMAPP-3149.