### PR TITLE
PREMIUMAPP-3223: Add restricted native apps meta layer to bblayer

### DIFF
--- a/conf/template/bblayers.conf.sample
+++ b/conf/template/bblayers.conf.sample
@@ -36,3 +36,5 @@ BBLAYERS =+ "${@'${MANIFEST_PATH_PROFILE_CONFIG}' if os.path.isfile('${MANIFEST_
 
 # Optional layers
 BBLAYERS =+ " ${@d.getVar('MANIFEST_PATH_IMAGE_SUPPORT') if d.getVar('MANIFEST_PATH_IMAGE_SUPPORT') is not None and os.path.isfile(d.getVar('MANIFEST_PATH_IMAGE_SUPPORT') + '/conf/layer.conf') else ''}"
+# Restricted Native Apps (Optional)
+BBLAYERS =+ " ${@d.getVar('MANIFEST_PATH_RESTRICTED_NATIVE_APPS') if d.getVar('MANIFEST_PATH_RESTRICTED_NATIVE_APPS') is not None and os.path.isfile(d.getVar('MANIFEST_PATH_RESTRICTED_NATIVE_APPS') + '/conf/layer.conf') else ''}"


### PR DESCRIPTION
Reason for change:
1. Add meta-layer for restricted native apps as optional to application layer bblayers

Test Procedure: Build should be successfull with and without the new mata-layer
Risks: low