### PR TITLE
Revert "RDKUI-799: update refui packages to use latest release v4.6.6"

### DIFF
--- a/conf/machine/include/package_revisions.inc
+++ b/conf/machine/include/package_revisions.inc
@@ -1,12 +1,12 @@
 # Both rdkresidentapp and residentui uses same repo.
-PV:pn-rdkresidentapp = "4.6.6"
+PV:pn-rdkresidentapp = "4.6.5"
 PR:pn-rdkresidentapp = "r0"
-SRCREV:pn-rdkresidentapp = "5da9633574ba7ea5339fed9daf1eff245b992da0"
+SRCREV:pn-rdkresidentapp = "f3c581f2becc21521764ebc8d91e3dbc35bfb637"
 PACKAGE_ARCH:pn-rdkresidentapp = "${APP_LAYER_ARCH}"
 
-PV:pn-residentui = "4.6.6"
+PV:pn-residentui = "4.6.5"
 PR:pn-residentui = "r0"
-SRCREV:pn-residentui = "5da9633574ba7ea5339fed9daf1eff245b992da0"
+SRCREV:pn-residentui = "f3c581f2becc21521764ebc8d91e3dbc35bfb637"
 PACKAGE_ARCH:pn-residentui = "${APP_LAYER_ARCH}"
 
 PV:pn-dab-adapter = "0.7.0"

--- a/recipes-apps/residentui/residentui.bb
+++ b/recipes-apps/residentui/residentui.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=fac1f1de1b2231cdc801d64ac2607c6b"
 # https://github.com/rdkcentral/rdke-refui/pull/7
 
 SRC_URI = "https://github.com/rdkcentral/rdke-refui/releases/download/${PV}/refui-${PV}.tar.gz;subdir=refui-${PV}"
-SRC_URI[sha256sum] = "620154e9c89dffb4e1dd577c26cc20d5bde546c73c075447634302a9c926b1e2"
+SRC_URI[sha256sum] = "01469b1b86abf6c508f287a2909e7e0ef96c966c6c1cd7d4011fb0638aeea8f4"
 
 S = "${WORKDIR}/refui-${PV}"
 


### PR DESCRIPTION
Reverts rdkcentral/meta-application-rdke-dev#92

Getting unpack error
ERROR: lib32-residentui-4.6.6-r0 do_unpack: Bitbake Fetcher Error: UnpackError