### PR TITLE
PREMIUMAPP-3253: Enable libloader-app-tools package in RDKE builds

### DIFF
--- a/recipes-core/packagegroups/packagegroup-application-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-application-layer.bb
@@ -12,5 +12,5 @@ RDEPENDS:packagegroup-application-layer = " \
                                            residentui \
                                            rdkresidentapp \
                                            ${@bb.utils.contains('DISTRO_FEATURES', 'enable-dab', 'dab-adapter mosquitto ', '', d)} \
-                                           ${@bb.utils.contains('DISTRO_FEATURES', 'enable_cobalt_plugin', 'cobalt-keymap ', '', d)} \
+                                           ${@bb.utils.contains('DISTRO_FEATURES', 'enable_cobalt_plugin', 'cobalt-keymap libloader-app-tools ', '', d)} \
                                          "


### PR DESCRIPTION
Reason for change: To enable libloader-app-tools package in RDKE build to execute nplb tests
Test Procedure: Refer ticket
Risks: low
Signed-off-by: Ansu Mathew <Ansu_Mathew@comcast.com>