### PR TITLE
PREMIUMAPP-3291 Fix compilation of mosquitto with older meta-openembedded

### DIFF
--- a/conf/machine/include/package_revisions.inc
+++ b/conf/machine/include/package_revisions.inc
@@ -14,9 +14,7 @@ PR:pn-dab-adapter = "r0"
 SRCREV:pn-dab-adapter = "4755f391c7e7b112c9cf285ce99013ddc8ee9b82"
 PACKAGE_ARCH:pn-dab-adapter = "${APP_LAYER_ARCH}"
 
-PV:pn-mosquitto = "2.0.18"
-PR:pn-mosquitto = "r0"
-SRCREV:pn-mosquitto = ""
+# mosquitto version is determined by the meta-openembedded layer version
 PACKAGE_ARCH:pn-mosquitto = "${APP_LAYER_ARCH}"
 
 PV:pn-dlt-daemon = "2.18.8"


### PR DESCRIPTION
Remove enforcement of PV, PR and SRCREV variables for the  mosquitto recipe to increase compatibility with multiple versions of the meta-openembedded layer. The mosquitto version is determined by the meta-openembedded layer version.

refs/tags/v4.1.0 uses 2.0.14
refs/tags/rdk-4.0.0 (rdkcentral) uses 2.0.18