### PR TITLE
PREMIUMAPP-3285 Add mapping for KEY_EXIT in DAB

### DIFF
--- a/recipes-thirdparty/dab-adapter/files/keymap.json
+++ b/recipes-thirdparty/dab-adapter/files/keymap.json
@@ -1,4 +1,5 @@
 {
+    "KEY_EXIT": 27,
     "KEY_POWER": 116,
     "KEY_HOME": 36,
     "KEY_VOLUME_UP": 175,


### PR DESCRIPTION
KEY_EXIT must be handled in UI to pass the "DAB Key Event System-wide Exit Key" yts test.