### PR TITLE
PREMIUMAPP-3315 : Allow empty package generation

### DIFF
--- a/recipes-thirdparty/cobalt-certscope/cobalt-certscope.bb
+++ b/recipes-thirdparty/cobalt-certscope/cobalt-certscope.bb
@@ -23,5 +23,6 @@ do_install() {
     fi
 }
 
+ALLOW_EMPTY:${PN} = "1"
 FILES:${PN} += "${datadir}"
 FILES:${PN} += "${systemd_unitdir}"


### PR DESCRIPTION
Reason for change: Resolve build issue observed with cert scope recipe
Test procedure: Refer ticket
Risks: low
Priority: P2