### PR TITLE
PREMIUMAPP-3286: Update dab-adapter revision to install settings.json with preferred languages

### DIFF
--- a/conf/machine/include/package_revisions.inc
+++ b/conf/machine/include/package_revisions.inc
@@ -11,7 +11,7 @@ PACKAGE_ARCH:pn-residentui = "${APP_LAYER_ARCH}"
 
 PV:pn-dab-adapter = "0.7.0"
 PR:pn-dab-adapter = "r0"
-SRCREV:pn-dab-adapter = "4755f391c7e7b112c9cf285ce99013ddc8ee9b82"
+SRCREV:pn-dab-adapter = "cd438ca9e913f584fdf8e54718e075a77d78937f"
 PACKAGE_ARCH:pn-dab-adapter = "${APP_LAYER_ARCH}"
 
 # mosquitto version is determined by the meta-openembedded layer version

--- a/recipes-thirdparty/dab-adapter/dab-adapter.inc
+++ b/recipes-thirdparty/dab-adapter/dab-adapter.inc
@@ -18,6 +18,7 @@ RDEPENDS_${PN} = " mosquitto openssl"
 SRC_URI:append = " file://dab-adapter.service "
 SRC_URI:append = " file://dab-adapter.path "
 SRC_URI:append = " file://keymap.json "
+SRC_URI:append = " file://settings.json "
 
 FILES:${PN} += "${systemd_unitdir}/system/dab-adapter.service"
 FILES:${PN} += "${systemd_unitdir}/system/dab-adapter.path"
@@ -38,4 +39,5 @@ do_install:append() {
   install -m 0644 ${WORKDIR}/mosquitto.conf ${D}/${sysconfdir}/mosquitto
   install -d ${D}/${sysconfdir}/dab
   install -m 0644 ${WORKDIR}/keymap.json ${D}/${sysconfdir}/dab
+  install -m 0644 ${WORKDIR}/settings.json ${D}/${sysconfdir}/dab
 }

--- a/recipes-thirdparty/dab-adapter/dab-adapter_0.7.0.bb
+++ b/recipes-thirdparty/dab-adapter/dab-adapter_0.7.0.bb
@@ -8,10 +8,10 @@ inherit cargo
 # how to get dab-adapter could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/dab-adapter/0.6.0"
 SRC_URI += "git://github.com/device-automation-bus/dab-adapter-rs.git;protocol=https;nobranch=1;branch=v0.7.0"
-SRCREV = "4755f391c7e7b112c9cf285ce99013ddc8ee9b82"
+SRCREV = "cd438ca9e913f584fdf8e54718e075a77d78937f"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
-PV:append = ".AUTOINC+1c497e1c04"
+PV:append = ".AUTOINC+cd438ca9e9"
 
 # please note if you have entries that do not begin with crate://
 # you must change them to how that package can be fetched

--- a/recipes-thirdparty/dab-adapter/files/settings.json
+++ b/recipes-thirdparty/dab-adapter/files/settings.json
@@ -1,0 +1,3 @@
+{
+    "supported_languages": ["en-US", "es-US"]
+}


### PR DESCRIPTION
The goal of this change is to bump dab-adapter revision to the HEAD of the v0.7.0 that contains a fix to read a `settings.json` file from `/etc/dab/` directory. This file can contain list of supported UI languages.