### PR TITLE
PREMIUMAPP-3386: Update dab-adapter - correct status codes for missing VA; device/info fixes

### DIFF
--- a/conf/machine/include/package_revisions.inc
+++ b/conf/machine/include/package_revisions.inc
@@ -11,7 +11,7 @@ PACKAGE_ARCH:pn-residentui = "${APP_LAYER_ARCH}"
 
 PV:pn-dab-adapter = "0.7.0"
 PR:pn-dab-adapter = "r0"
-SRCREV:pn-dab-adapter = "cd438ca9e913f584fdf8e54718e075a77d78937f"
+SRCREV:pn-dab-adapter = "472acdda1c370ec13c019072b4790c37957cad4c"
 PACKAGE_ARCH:pn-dab-adapter = "${APP_LAYER_ARCH}"
 
 # mosquitto version is determined by the meta-openembedded layer version

--- a/conf/machine/include/package_revisions.inc
+++ b/conf/machine/include/package_revisions.inc
@@ -11,7 +11,7 @@ PACKAGE_ARCH:pn-residentui = "${APP_LAYER_ARCH}"
 
 PV:pn-dab-adapter = "0.7.0"
 PR:pn-dab-adapter = "r0"
-SRCREV:pn-dab-adapter = "472acdda1c370ec13c019072b4790c37957cad4c"
+SRCREV:pn-dab-adapter = "3f093a72f61760d9b2e442b9ef6d7190c6dba7d6"
 PACKAGE_ARCH:pn-dab-adapter = "${APP_LAYER_ARCH}"
 
 # mosquitto version is determined by the meta-openembedded layer version

--- a/recipes-thirdparty/dab-adapter/dab-adapter_0.7.0.bb
+++ b/recipes-thirdparty/dab-adapter/dab-adapter_0.7.0.bb
@@ -8,10 +8,10 @@ inherit cargo
 # how to get dab-adapter could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/dab-adapter/0.6.0"
 SRC_URI += "git://github.com/device-automation-bus/dab-adapter-rs.git;protocol=https;nobranch=1;branch=v0.7.0"
-SRCREV = "472acdda1c370ec13c019072b4790c37957cad4c"
+SRCREV = "3f093a72f61760d9b2e442b9ef6d7190c6dba7d6"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
-PV:append = ".AUTOINC+472acdda1c"
+PV:append = ".AUTOINC+3f093a72f6"
 
 # please note if you have entries that do not begin with crate://
 # you must change them to how that package can be fetched

--- a/recipes-thirdparty/dab-adapter/dab-adapter_0.7.0.bb
+++ b/recipes-thirdparty/dab-adapter/dab-adapter_0.7.0.bb
@@ -8,10 +8,10 @@ inherit cargo
 # how to get dab-adapter could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/dab-adapter/0.6.0"
 SRC_URI += "git://github.com/device-automation-bus/dab-adapter-rs.git;protocol=https;nobranch=1;branch=v0.7.0"
-SRCREV = "cd438ca9e913f584fdf8e54718e075a77d78937f"
+SRCREV = "472acdda1c370ec13c019072b4790c37957cad4c"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
-PV:append = ".AUTOINC+cd438ca9e9"
+PV:append = ".AUTOINC+472acdda1c"
 
 # please note if you have entries that do not begin with crate://
 # you must change them to how that package can be fetched


### PR DESCRIPTION
Do not merge until: https://github.com/device-automation-bus/dab-adapter-rs/pull/78 is merged. Then update refs. 