### PR TITLE
PREMIUMAPP-3381 Copy Cobalt keymap to /usr/share/content/data/etc

### DIFF
--- a/recipes-thirdparty/cobalt-keymap/cobalt-keymap.bb
+++ b/recipes-thirdparty/cobalt-keymap/cobalt-keymap.bb
@@ -14,8 +14,11 @@ do_configure[noexec] = "1"
 do_patch[noexec] = "1"
 
 do_install() {
+        install -d ${D}/usr/share/content/data/etc
+        install -m 0644 ${S}/keymapping.json ${D}/usr/share/content/data/etc/keymapping.json
+# left for backward compatibility
         install -d ${D}/usr/share/content/data/app/cobalt/content/etc
         install -m 0644 ${S}/keymapping.json ${D}/usr/share/content/data/app/cobalt/content/etc/keymapping.json
 }
 
-FILES:${PN} += "/usr/share/content/data/app/cobalt/content/etc/keymapping.json"
+FILES:${PN} += "/usr/share/content/data"


### PR DESCRIPTION
Add another copy of Cobalt keymap to /usr/share/content/data/etc which which is an evergreen location independent path.

Please note that this keymap will only be used if the corresponding change in the larboard component is accepted.
