### PR TITLE
feat: update dab-adapter

### DIFF
--- a/conf/machine/include/package_revisions.inc
+++ b/conf/machine/include/package_revisions.inc
@@ -11,7 +11,7 @@ PACKAGE_ARCH:pn-residentui = "${APP_LAYER_ARCH}"
 
 PV:pn-dab-adapter = "0.7.0"
 PR:pn-dab-adapter = "r0"
-SRCREV:pn-dab-adapter = "1b439ab62ba65fdc06bd9d3bb34a5b7208e03d30"
+SRCREV:pn-dab-adapter = "6fd4cd07753775d8c933307fc15108bea27abf49"
 PACKAGE_ARCH:pn-dab-adapter = "${APP_LAYER_ARCH}"
 
 # mosquitto version is determined by the meta-openembedded layer version

--- a/recipes-thirdparty/dab-adapter/dab-adapter_0.7.0.bb
+++ b/recipes-thirdparty/dab-adapter/dab-adapter_0.7.0.bb
@@ -8,10 +8,10 @@ inherit cargo
 # how to get dab-adapter could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/dab-adapter/0.6.0"
 SRC_URI += "git://github.com/device-automation-bus/dab-adapter-rs.git;protocol=https;nobranch=1;branch=v0.7.0"
-SRCREV = "1b439ab62ba65fdc06bd9d3bb34a5b7208e03d30"
+SRCREV = "6fd4cd07753775d8c933307fc15108bea27abf49"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
-PV:append = ".AUTOINC+1b439ab62b"
+PV:append = ".AUTOINC+6fd4cd0775"
 
 # please note if you have entries that do not begin with crate://
 # you must change them to how that package can be fetched


### PR DESCRIPTION
Changelog from: https://github.com/device-automation-bus/dab-adapter-rs:
- Add audio_volume_range setting and runtime check is value is within range (#81)
- Enable input/long-key-press in operations/list output (#83)
- Add feature flag for DAB2.1 that extends versions. Update documentation (#84)
- Update Cargo lock (#86)